### PR TITLE
feat: detailheader 구현

### DIFF
--- a/src/components/DetailHeader.jsx
+++ b/src/components/DetailHeader.jsx
@@ -1,23 +1,19 @@
 import { styled } from 'styled-components';
 
-import { ReactComponent as CloseIcon } from '../assets/images/large-cancel.svg';
+import closeIcon from '../assets/images/large-cancel.svg';
 
 const DetailHeader = () => {
+  const closeDetail = () => {};
   return (
-    <Test>
-      <Container>
-        <TitleWrapper>
-          <Title>상세정보</Title>
-          <CloseIcon className="closeIcon" />
-        </TitleWrapper>
-      </Container>
-    </Test>
+    <Container>
+      <TitleWrapper>
+        <Title>상세정보</Title>
+        <CloseIcon src={closeIcon} onClick={closeDetail} />
+      </TitleWrapper>
+    </Container>
   );
 };
-const Test = styled.div`
-  width: 360px;
-  height: 800px;
-`;
+
 const Container = styled.div`
   width: 100%;
   height: 54px;
@@ -30,9 +26,9 @@ const TitleWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  .closeIcon {
-    cursor: pointer;
-  }
+`;
+const CloseIcon = styled.img`
+  cursor: pointer;
 `;
 const Title = styled.p`
   color: #ffffff;

--- a/src/components/DetailHeader.jsx
+++ b/src/components/DetailHeader.jsx
@@ -1,0 +1,41 @@
+import { styled } from 'styled-components';
+
+import { ReactComponent as CloseIcon } from '../assets/images/large-cancel.svg';
+
+const DetailHeader = () => {
+  return (
+    <Test>
+      <Container>
+        <TitleWrapper>
+          <Title>상세정보</Title>
+          <CloseIcon className="closeIcon" />
+        </TitleWrapper>
+      </Container>
+    </Test>
+  );
+};
+const Test = styled.div`
+  width: 360px;
+  height: 800px;
+`;
+const Container = styled.div`
+  width: 100%;
+  height: 54px;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+  background-color: ${({ theme }) => theme.colors.YELLOW};
+  padding: 15px 22px;
+`;
+const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  .closeIcon {
+    cursor: pointer;
+  }
+`;
+const Title = styled.p`
+  color: #ffffff;
+  ${({ theme }) => theme.typographies.mainTitle}
+`;
+export default DetailHeader;


### PR DESCRIPTION
<img width="315" alt="image" src="https://github.com/mju-likelion/hackathon-team2-web/assets/117571282/a272dc5d-be5d-441c-8f8f-c2c384c52716">

detailheader입니다.